### PR TITLE
Using CliPlugin instead of Plugin in Hello World example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following example shows a Hello World Compiler Plugin.
 The Hello World plugin auto implements the `helloWorld` function by rewriting the Kotlin AST before the compiler proceeds.
 
 ```kotlin
-val Meta.helloWorld: Plugin
+val Meta.helloWorld: CliPlugin
   get() =
     "Hello World" {
       meta(

--- a/hello-world/create-plugin/src/main/kotlin/io/arrowkt/example/HelloWorldPlugin.kt
+++ b/hello-world/create-plugin/src/main/kotlin/io/arrowkt/example/HelloWorldPlugin.kt
@@ -1,12 +1,12 @@
 package io.arrowkt.example
 
+import arrow.meta.CliPlugin
 import arrow.meta.Meta
-import arrow.meta.Plugin
 import arrow.meta.invoke
 import arrow.meta.quotes.Transform
 import arrow.meta.quotes.namedFunction
 
-val Meta.helloWorld: Plugin
+val Meta.helloWorld: CliPlugin
   get() =
     "Hello World" {
       meta(

--- a/hello-world/create-plugin/src/main/kotlin/io/arrowkt/example/MetaPlugin.kt
+++ b/hello-world/create-plugin/src/main/kotlin/io/arrowkt/example/MetaPlugin.kt
@@ -1,13 +1,13 @@
 package io.arrowkt.example
 
+import arrow.meta.CliPlugin
 import arrow.meta.Meta
-import arrow.meta.Plugin
 import arrow.meta.phases.CompilerContext
 import kotlin.contracts.ExperimentalContracts
 
 class MetaPlugin : Meta {
     @ExperimentalContracts
-    override fun intercept(ctx: CompilerContext): List<Plugin> =
+    override fun intercept(ctx: CompilerContext): List<CliPlugin> =
         listOf(
             helloWorld
         )


### PR DESCRIPTION
Hello, I tried to compile hello world example, and I didn’t succeed because `Plugin` type expects one type argument. It seems we can use `CliPlugin` here.

<img width="548" alt="image" src="https://user-images.githubusercontent.com/23008732/79040989-ff14a080-7bf4-11ea-9b13-f37449811a6a.png">

Thank you for amazing libraries! 