### PR TITLE
Improve the example to add new meta plugins

### DIFF
--- a/hello-world/create-plugin/build.gradle
+++ b/hello-world/create-plugin/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Paths
+
 /*
  * Copyright (C) 2019 The Arrow Authors
  *
@@ -35,7 +37,11 @@ task createNewPlugin(type: Jar, dependsOn: classes) {
     archiveClassifier = "all"
     from 'build/classes/kotlin/main'
     from 'build/resources/main'
-    from (zipTree(sourceSets.main.compileClasspath.find{ it.absolutePath.contains("io.arrow-kt/compiler-plugin") })) {
+    from (
+       zipTree(sourceSets.main.compileClasspath.find {
+           it.absolutePath.contains(Paths.get("io.arrow-kt","compiler-plugin").toString())
+       })
+    ) {
         exclude 'META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar'
     }
 }

--- a/hello-world/use-plugin/build.gradle
+++ b/hello-world/use-plugin/build.gradle
@@ -21,6 +21,17 @@ plugins {
 dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
     compileOnly "io.arrow-kt:arrow-annotations:$ARROW_VERSION"
+
+    // Depending on the example, it could be necessary to add these dependencies:
+    //
+    //   kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION") {
+    //       exclude("org.jetbrains.kotlin", "kotlin-stdlib")
+    //       exclude("org.jetbrains.kotlin", "kotlin-compiler")
+    //       exclude("org.jetbrains.kotlin", "kotlin-compiler-embeddable")
+    //   }
+    //   kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION")
+    //   kotlinCompilerClasspath("org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$KOTLIN_VERSION")
+
     testImplementation "io.kotlintest:kotlintest-runner-junit4:$KOTLIN_TEST_VERSION"
 }
 


### PR DESCRIPTION
These improvements come from the review of the example created by @AhmedMourad0 :

- Include commented dependencies that could be necessary to use other features from Arrow Meta Compiler Plugin
- Look for the path of Arrow Meta Compiler Plugin artifact without hard-coded path separator to work in any platform.